### PR TITLE
Use xcode26.4 realm-core fix for SwiftPM

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -4,6 +4,7 @@ import PackageDescription
 import Foundation
 
 let coreVersion = Version("14.14.0")
+let corePackageVersion = Version("14.14.0-xcode26.4-fix")
 let cocoaVersion = Version("10.54.5")
 
 #if compiler(>=6)
@@ -161,7 +162,7 @@ let package = Package(
             targets: ["RealmSwift"]),
     ],
     dependencies: [
-        .package(url: "https://github.com/realm/realm-core.git", exact: coreVersion)
+        .package(url: "https://github.com/Doist/realm-core.git", exact: corePackageVersion)
     ],
     targets: [
       .target(


### PR DESCRIPTION
Point the SwiftPM dependency to Doist’s v14.14.0-xcode26.4-fix release to only include this trivial fix: https://github.com/Doist/realm-core/commit/4e35bfc6a0a4880ee113e538b014229825e241d6.

Once this PR is merged, I’ll push a new tag (e.g., 10.54.5-xcode26.4-fix) and update the Todoist iOS dependency to use it so we can build the app with Xcode 26.4. Supporting Xcode 26.4 on CI will be handled as a separate task.

- [Twist](https://twist.com/a/1585/ch/6550/t/7687326/)